### PR TITLE
Improved tooltips

### DIFF
--- a/frontend/components/attribute-table.vue
+++ b/frontend/components/attribute-table.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="loading" class="d-flex flex-column align-center ga-4">
     <span>Loading Attributes...</span>
-    <v-progress-circular :size="75" color="primary" indeterminate/>
+    <v-progress-circular :size="75" color="primary" indeterminate class="ml-2"/>
   </div>
   <div v-else>
     <v-table>

--- a/frontend/components/attribute-value.vue
+++ b/frontend/components/attribute-value.vue
@@ -16,12 +16,8 @@
     </v-chip>
   </template>
 
-  <em v-else-if="attribute.value === null">
-    null
-  </em>
-
-  <em v-else-if="attribute.value === undefined">
-    undefined
+  <em v-else>
+    No Value
   </em>
 
 

--- a/frontend/components/attribute-value.vue
+++ b/frontend/components/attribute-value.vue
@@ -1,21 +1,30 @@
 
 
 <template>
-  <span v-if="attribute.value === undefined || attribute.value === null">
-    <em>no value</em>
-  </span>
-  <v-chip v-else>
-    <span v-if="attribute.dataType === ScalarTypeEnum.Datetime">
+  <template v-if="attribute.value !== null && attribute.value !== undefined">
+    <v-chip v-if="attribute.dataType === ScalarTypeEnum.Datetime">
       {{ renderDateTime(attribute.value as string) }}
-    </span>
-    <span v-if="attribute.dataType === ScalarTypeEnum.Float">
+    </v-chip>
+
+    <v-chip v-else-if="attribute.dataType === ScalarTypeEnum.Float">
       {{ typeof attribute.value === "number" ? attribute.value.toFixed(2) : attribute.value }}
       {{ attribute.maxValue === 100 ? '%' : ''}}
-    </span>
-    <span v-else>
-      {{ attribute.value }}
-    </span>
-  </v-chip>
+    </v-chip>
+
+    <v-chip v-else>
+      {{attribute.value}}
+    </v-chip>
+  </template>
+
+  <em v-else-if="attribute.value === null">
+    null
+  </em>
+
+  <em v-else-if="attribute.value === undefined">
+    undefined
+  </em>
+
+
 </template>
 
 <script setup lang="ts">

--- a/frontend/components/equipment-card.vue
+++ b/frontend/components/equipment-card.vue
@@ -19,10 +19,11 @@
 
         <v-card-title class="text-subtitle-1 d-flex flex-row justify-space-between align-center h-100" >
           <ContrastLabel class="mr-4" :label="metric.label"/>
-          <ContrastLabel v-if="metric.displayValue !== undefined">
+          <ContrastLabel v-if="metric.displayValue !== undefined && metric.displayValue !== null">
             {{metric.displayValue}}
           </ContrastLabel>
-          <em v-else>no value</em>
+          <em v-else-if="metric.displayValue === null">null</em>
+          <em v-else>undefined</em>
         </v-card-title>
       </v-card>
     </v-card-text>

--- a/frontend/components/equipment-card.vue
+++ b/frontend/components/equipment-card.vue
@@ -22,8 +22,8 @@
           <ContrastLabel v-if="metric.displayValue !== undefined && metric.displayValue !== null">
             {{metric.displayValue}}
           </ContrastLabel>
-          <em v-else-if="metric.displayValue === null">null</em>
-          <em v-else>undefined</em>
+          <em v-else-if="metric.displayValue === null">Invalid Value</em>
+          <em v-else>No Value</em>
         </v-card-title>
       </v-card>
     </v-card-text>

--- a/frontend/components/metric-progress-circular.vue
+++ b/frontend/components/metric-progress-circular.vue
@@ -10,6 +10,8 @@
     <div :class="labelClass">
       <h3 class="font-weight-medium">{{ label }}</h3>
       <span v-if="typeof value === 'number'">{{value.toFixed(1)}}%</span>
+      <span v-else-if="typeof value === null">null</span>
+      <span v-else-if="value === undefined">undefined</span>
       <span v-else>??</span>
     </div>
   </v-progress-circular>

--- a/frontend/components/metric-progress-circular.vue
+++ b/frontend/components/metric-progress-circular.vue
@@ -10,8 +10,7 @@
     <div :class="labelClass">
       <h3 class="font-weight-medium">{{ label }}</h3>
       <span v-if="typeof value === 'number'">{{value.toFixed(1)}}%</span>
-      <span v-else-if="typeof value === null">null</span>
-      <span v-else-if="value === undefined">undefined</span>
+      <span v-else-if="typeof value === null || value === undefined">No Value</span>
       <span v-else>??</span>
     </div>
   </v-progress-circular>

--- a/frontend/pages/equipment/[equipmentID].vue
+++ b/frontend/pages/equipment/[equipmentID].vue
@@ -61,11 +61,11 @@
             <v-card :class="`rounded-ts-0 fill-height border-md border-${tab.color} border-opacity-100`">
               <v-card-text>
                 <em v-if="tab.equipment === undefined">
-                  {{tab.label}} Component is undefined
+                  {{tab.label}} Component Missing
                 </em>
 
                 <em v-else-if="tab.equipment.attributes === undefined">
-                  {{tab.label}} Attributes are undefined
+                  Could Not Retrieve Attributes
                 </em>
 
                 <attribute-table v-else :attributes="tab.equipment.attributes" :loading="pending"/>

--- a/frontend/pages/equipment/[equipmentID].vue
+++ b/frontend/pages/equipment/[equipmentID].vue
@@ -60,7 +60,16 @@
           >
             <v-card :class="`rounded-ts-0 fill-height border-md border-${tab.color} border-opacity-100`">
               <v-card-text>
-                <attribute-table :attributes="tab.equipment?.attributes" :loading="pending"/>
+                <em v-if="tab.equipment === undefined">
+                  {{tab.label}} Component is undefined
+                </em>
+
+                <em v-else-if="tab.equipment.attributes === undefined">
+                  {{tab.label}} Attributes are undefined
+                </em>
+
+                <attribute-table v-else :attributes="tab.equipment.attributes" :loading="pending"/>
+
               </v-card-text>
             </v-card>
           </v-tabs-window-item>
@@ -81,7 +90,7 @@
 <script setup lang="ts">
 import { useTheme } from "vuetify";
 
-import type { IEquipmentWithMetric, TimeSeriesItemValue } from "~/lib/equipment";
+import type { TimeSeriesItemValue } from "~/lib/equipment";
 
 
 

--- a/frontend/utils/equipment.ts
+++ b/frontend/utils/equipment.ts
@@ -14,7 +14,7 @@ export interface IMockEquipment {
 export interface Metric {
   label: string;
   value: number;
-  displayValue: string | undefined | null;
+  displayValue: string | undefined;
   progressValue: number;
 }
 
@@ -23,10 +23,8 @@ export type MetricKey = "availability" | "quality" | "performance" | "oee";
 
 
 export function makePercentMetric(label: string, value: unknown): Metric {
-  if(value === undefined) {
+  if(value === undefined || value === null) {
     return { label, value: 0, displayValue: undefined, progressValue: 0 };
-  } else if(value === null) {
-    return { label, value: 0, displayValue: null, progressValue: 0 };
   }
   if(typeof value !== "number") {
     // Default undefined metric

--- a/frontend/utils/equipment.ts
+++ b/frontend/utils/equipment.ts
@@ -14,7 +14,7 @@ export interface IMockEquipment {
 export interface Metric {
   label: string;
   value: number;
-  displayValue: string | undefined;
+  displayValue: string | undefined | null;
   progressValue: number;
 }
 
@@ -23,8 +23,10 @@ export type MetricKey = "availability" | "quality" | "performance" | "oee";
 
 
 export function makePercentMetric(label: string, value: unknown): Metric {
-  if(value === undefined || value === null) {
+  if(value === undefined) {
     return { label, value: 0, displayValue: undefined, progressValue: 0 };
+  } else if(value === null) {
+    return { label, value: 0, displayValue: null, progressValue: 0 };
   }
   if(typeof value !== "number") {
     // Default undefined metric


### PR DESCRIPTION
When things are null, labels say null
When things are undefined, labels say undefined
Parent objects being undefined displays different error than Child object being undefined